### PR TITLE
[Feature] Add support for client certificate password and test with real services that require client certificate auth

### DIFF
--- a/examples/WireMock.Net.Console.Record.NETCoreApp/Program.cs
+++ b/examples/WireMock.Net.Console.Record.NETCoreApp/Program.cs
@@ -10,11 +10,12 @@ namespace WireMock.Net.Console.Record.NETCoreApp
         {
             var server = FluentMockServer.Start(new FluentMockServerSettings
             {
-                Urls = new[] { "http://localhost:9095/", "https://localhost:9096/" },
+                Urls = new[] { "http://localhost:9090/", "https://localhost:9096/" },
                 StartAdminInterface = true,
                 ProxyAndRecordSettings = new ProxyAndRecordSettings
                 {
                     Url = "https://www.msn.com",
+                    X509Certificate2ThumbprintOrSubjectName = "x3bwbapi-dev.nzlb.service.dev",
                     SaveMapping = true
                 }
             });

--- a/examples/WireMock.Net.ConsoleApplication/MainApp.cs
+++ b/examples/WireMock.Net.ConsoleApplication/MainApp.cs
@@ -96,17 +96,23 @@ namespace WireMock.Net.ConsoleApplication
                 .RespondWith(Response.Create().WithStatusCode(200).WithBody("partial = 200"));
 
             // http://localhost:8080/any/any?start=1000&stop=1&stop=2
+            //server
+            //    .Given(Request.Create().WithPath("/*").UsingGet())
+            //    .WithGuid("90356dba-b36c-469a-a17e-669cd84f1f05")
+            //    .AtPriority(server.Mappings.Count() + 1)
+            //    .RespondWith(Response.Create()
+            //        .WithStatusCode(200)
+            //        .WithHeader("Content-Type", "application/json")
+            //        .WithHeader("Transformed-Postman-Token", "token is {{request.headers.Postman-Token}}")
+            //        .WithBody(@"{""msg"": ""Hello world CATCH-ALL on /*, {{request.path}}, bykey={{request.query.start}}, bykey={{request.query.stop}}, byidx0={{request.query.stop.[0]}}, byidx1={{request.query.stop.[1]}}"" }")
+            //        .WithTransformer()
+            //        .WithDelay(TimeSpan.FromMilliseconds(100))
+            //    );
             server
                 .Given(Request.Create().WithPath("/*").UsingGet())
                 .WithGuid("90356dba-b36c-469a-a17e-669cd84f1f05")
-                .AtPriority(server.Mappings.Count() + 1)
                 .RespondWith(Response.Create()
-                    .WithStatusCode(200)
-                    .WithHeader("Content-Type", "application/json")
-                    .WithHeader("Transformed-Postman-Token", "token is {{request.headers.Postman-Token}}")
-                    .WithBody(@"{""msg"": ""Hello world CATCH-ALL on /*, {{request.path}}, bykey={{request.query.start}}, bykey={{request.query.stop}}, byidx0={{request.query.stop.[0]}}, byidx1={{request.query.stop.[1]}}"" }")
-                    .WithTransformer()
-                    .WithDelay(TimeSpan.FromMilliseconds(100))
+                .WithProxy("https://semhub-test.lbtest.anznb.co.nz:5200", "D2DBF134A8D06ACCD0E1FAD9B8B28678DF7A9816")
                 );
 
             System.Console.WriteLine("Press any key to stop the server");

--- a/src/WireMock.Net.StandAlone/StandAloneApp.cs
+++ b/src/WireMock.Net.StandAlone/StandAloneApp.cs
@@ -37,6 +37,9 @@ namespace WireMock.Net.StandAlone
 
             [ValueArgument(typeof(string), "X509Certificate2", Description = "The X509Certificate2 Filename to use.", Optional = true)]
             public string X509Certificate2Filename { get; set; }
+
+            [ValueArgument(typeof(string), "X509Certificate2Password", Description = "The X509Certificate2 password to use.", Optional = true)]
+            public string X509Certificate2Password { get; set; }
         }
 
         /// <summary>
@@ -91,7 +94,8 @@ namespace WireMock.Net.StandAlone
                     {
                         Url = options.ProxyURL,
                         SaveMapping = options.SaveMapping,
-                        X509Certificate2Filename = options.X509Certificate2Filename
+                        X509Certificate2Filename = options.X509Certificate2Filename,
+                        X509Certificate2Password = options.X509Certificate2Password
                     };
                 }
 

--- a/src/WireMock.Net.StandAlone/StandAloneApp.cs
+++ b/src/WireMock.Net.StandAlone/StandAloneApp.cs
@@ -35,11 +35,8 @@ namespace WireMock.Net.StandAlone
             [SwitchArgument("SaveProxyMapping", true, Description = "Save the proxied request and response mapping files in ./__admin/mappings.  (default set to true).", Optional = true)]
             public bool SaveMapping { get; set; }
 
-            [ValueArgument(typeof(string), "X509Certificate2", Description = "The X509Certificate2 Filename to use.", Optional = true)]
-            public string X509Certificate2Filename { get; set; }
-
-            [ValueArgument(typeof(string), "X509Certificate2Password", Description = "The X509Certificate2 password to use.", Optional = true)]
-            public string X509Certificate2Password { get; set; }
+            [ValueArgument(typeof(string), "X509Certificate2ThumbprintOrSubjectName", Description = "The X509Certificate2 Thumbprint or SubjectName to use.", Optional = true)]
+            public string X509Certificate2ThumbprintOrSubjectName { get; set; }
         }
 
         /// <summary>
@@ -94,8 +91,7 @@ namespace WireMock.Net.StandAlone
                     {
                         Url = options.ProxyURL,
                         SaveMapping = options.SaveMapping,
-                        X509Certificate2Filename = options.X509Certificate2Filename,
-                        X509Certificate2Password = options.X509Certificate2Password
+                        X509Certificate2ThumbprintOrSubjectName = options.X509Certificate2ThumbprintOrSubjectName
                     };
                 }
 

--- a/src/WireMock.Net/Admin/Mappings/ResponseModel.cs
+++ b/src/WireMock.Net/Admin/Mappings/ResponseModel.cs
@@ -84,5 +84,15 @@ namespace WireMock.Admin.Mappings
         /// </summary>
         /// <value>ProxyUrl</value>
         public string ProxyUrl { get; set; }
+
+        /// <summary>
+        /// The client X509Certificate2Filename to use.
+        /// </summary>
+        public string X509Certificate2Filename { get; set; }
+
+        /// <summary>
+        /// The X509Certificate2 password.
+        /// </summary>
+        public string X509Certificate2Password { get; set; }
     }
 }

--- a/src/WireMock.Net/Admin/Mappings/ResponseModel.cs
+++ b/src/WireMock.Net/Admin/Mappings/ResponseModel.cs
@@ -86,13 +86,8 @@ namespace WireMock.Admin.Mappings
         public string ProxyUrl { get; set; }
 
         /// <summary>
-        /// The client X509Certificate2Filename to use.
+        /// The client X509Certificate2 Thumbprint or SubjectName to use.
         /// </summary>
-        public string X509Certificate2Filename { get; set; }
-
-        /// <summary>
-        /// The X509Certificate2 password.
-        /// </summary>
-        public string X509Certificate2Password { get; set; }
+        public string X509Certificate2ThumbprintOrSubjectName { get; set; }
     }
 }

--- a/src/WireMock.Net/Http/CertificateUtil.cs
+++ b/src/WireMock.Net/Http/CertificateUtil.cs
@@ -22,14 +22,12 @@ namespace WireMock.Http
                     if (matchingCertificates.Count == 0)
                     {
                         // No certificates matched the search criteria.
-                        throw new Exception("no cert fount");
+                        throw new Exception($"No certificate found with Thumbprint or SubjectName '{thumbprintOrSubjectName}'");
                     }
                 }
-
                 // Use the first matching certificate.
                 return matchingCertificates[0];
             }
-
             finally
             {
                 if (certStore != null)

--- a/src/WireMock.Net/Http/CertificateUtil.cs
+++ b/src/WireMock.Net/Http/CertificateUtil.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace WireMock.Http
+{
+    internal static class CertificateUtil
+    {
+        public static X509Certificate2 GetCertificate(string thumbprintOrSubjectName)
+        {
+            X509Store certStore = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            try
+            {
+                //Certificate must be in the local machine store
+                certStore.Open(OpenFlags.ReadOnly);
+
+                //Attempt to find by thumbprint first
+                var matchingCertificates = certStore.Certificates.Find(X509FindType.FindByThumbprint, thumbprintOrSubjectName, false);
+                if (matchingCertificates.Count == 0)
+                {
+                    //Fallback to subject name
+                    matchingCertificates = certStore.Certificates.Find(X509FindType.FindBySubjectName, thumbprintOrSubjectName, false);
+                    if (matchingCertificates.Count == 0)
+                    {
+                        // No certificates matched the search criteria.
+                        throw new Exception("no cert fount");
+                    }
+                }
+
+                // Use the first matching certificate.
+                return matchingCertificates[0];
+            }
+
+            finally
+            {
+                if (certStore != null)
+                {
+#if NETSTANDARD || NET46
+                    certStore.Dispose();
+#else
+                    certStore.Close();
+#endif
+                }
+            }
+        }
+    }
+}

--- a/src/WireMock.Net/Http/HttpClientHelper.cs
+++ b/src/WireMock.Net/Http/HttpClientHelper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
@@ -9,9 +10,10 @@ namespace WireMock.Http
 {
     internal static class HttpClientHelper
     {
-        private static HttpClient CreateHttpClient(string clientX509Certificate2Filename = null, string clientX509Certificate2Password = null)
+        
+        private static HttpClient CreateHttpClient(string clientX509Certificate2ThumbprintOrSubjectName = null)
         {
-            if (!string.IsNullOrEmpty(clientX509Certificate2Filename))
+            if (!string.IsNullOrEmpty(clientX509Certificate2ThumbprintOrSubjectName))
             {
 #if NETSTANDARD || NET46
                 var handler = new HttpClientHandler
@@ -21,16 +23,10 @@ namespace WireMock.Http
                     ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
                 };
 
-                X509Certificate2 x509Certificate2;
-                if (String.IsNullOrEmpty(clientX509Certificate2Password)) {
-                    x509Certificate2 = new X509Certificate2(clientX509Certificate2Filename);
-                }
-                else
-                {
-                    x509Certificate2 = new X509Certificate2(clientX509Certificate2Password);
-                }
+                var x509Certificate2 = CertificateUtil.GetCertificate(clientX509Certificate2ThumbprintOrSubjectName);
                 handler.ClientCertificates.Add(x509Certificate2);
-                return new HttpClient(handler);
+
+
 #else
                 var handler = new WebRequestHandler
                 {
@@ -39,15 +35,7 @@ namespace WireMock.Http
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
                 };
 
-                X509Certificate2 x509Certificate2;
-                if (String.IsNullOrEmpty(clientX509Certificate2Password))
-                {
-                    x509Certificate2 = new X509Certificate2(clientX509Certificate2Filename);
-                }
-                else
-                {
-                    x509Certificate2 = new X509Certificate2(clientX509Certificate2Filename, clientX509Certificate2Password);
-                }
+                var x509Certificate2 = CertificateUtil.GetCertificate(clientX509Certificate2ThumbprintOrSubjectName);
                 handler.ClientCertificates.Add(x509Certificate2);
                 return new HttpClient(handler);
 #endif
@@ -56,9 +44,9 @@ namespace WireMock.Http
             return new HttpClient();
         }
 
-        public static async Task<ResponseMessage> SendAsync(RequestMessage requestMessage, string url, string clientX509Certificate2Filename = null, string clientX509Certificate2Password = null)
+        public static async Task<ResponseMessage> SendAsync(RequestMessage requestMessage, string url, string clientX509Certificate2ThumbprintOrSubjectName = null)
         {
-            var client = CreateHttpClient(clientX509Certificate2Filename, clientX509Certificate2Password);
+            var client = CreateHttpClient(clientX509Certificate2ThumbprintOrSubjectName);
 
             var httpRequestMessage = new HttpRequestMessage(new HttpMethod(requestMessage.Method), url);
 
@@ -81,21 +69,29 @@ namespace WireMock.Http
             }
 
             // Call the URL
-            var httpResponseMessage = await client.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseContentRead);
-
-            // Transform response
-            var responseMessage = new ResponseMessage
+            try
             {
-                StatusCode = (int)httpResponseMessage.StatusCode,
-                Body = await httpResponseMessage.Content.ReadAsStringAsync()
-            };
+                var httpResponseMessage = await client.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseContentRead);
 
-            foreach (var header in httpResponseMessage.Headers)
-            {
-                responseMessage.AddHeader(header.Key, header.Value.FirstOrDefault());
+
+                // Transform response
+                var responseMessage = new ResponseMessage
+                {
+                    StatusCode = (int)httpResponseMessage.StatusCode,
+                    Body = await httpResponseMessage.Content.ReadAsStringAsync()
+                };
+
+                foreach (var header in httpResponseMessage.Headers)
+                {
+                    responseMessage.AddHeader(header.Key, header.Value.FirstOrDefault());
+                }
+
+                return responseMessage;
             }
-
-            return responseMessage;
+            catch(Exception ex)
+            {
+                throw ex;
+            }
         }
     }
 }

--- a/src/WireMock.Net/ResponseBuilders/IProxyResponseBuilder.cs
+++ b/src/WireMock.Net/ResponseBuilders/IProxyResponseBuilder.cs
@@ -19,7 +19,8 @@ namespace WireMock.ResponseBuilders
         /// </summary>
         /// <param name="proxyUrl">The proxy url.</param>
         /// <param name="clientX509Certificate2Filename">The X509Certificate2 file to use for client authentication.</param>
+        /// /// <param name="clientX509Certificate2Password">The X509Certificate2 password.</param>
         /// <returns>A <see cref="IResponseBuilder"/>.</returns>
-        IResponseBuilder WithProxy([NotNull] string proxyUrl, [CanBeNull] string clientX509Certificate2Filename);
+        IResponseBuilder WithProxy([NotNull] string proxyUrl, [CanBeNull] string clientX509Certificate2Filename, [CanBeNull] string clientX509Certificate2Password);
     }
 }

--- a/src/WireMock.Net/ResponseBuilders/IProxyResponseBuilder.cs
+++ b/src/WireMock.Net/ResponseBuilders/IProxyResponseBuilder.cs
@@ -18,9 +18,8 @@ namespace WireMock.ResponseBuilders
         /// With Proxy URL using X509Certificate2.
         /// </summary>
         /// <param name="proxyUrl">The proxy url.</param>
-        /// <param name="clientX509Certificate2Filename">The X509Certificate2 file to use for client authentication.</param>
-        /// /// <param name="clientX509Certificate2Password">The X509Certificate2 password.</param>
+        /// <param name="clientX509Certificate2ThumbprintOrSubjectName">The X509Certificate2 file to use for client authentication.</param>
         /// <returns>A <see cref="IResponseBuilder"/>.</returns>
-        IResponseBuilder WithProxy([NotNull] string proxyUrl, [CanBeNull] string clientX509Certificate2Filename, [CanBeNull] string clientX509Certificate2Password);
+        IResponseBuilder WithProxy([NotNull] string proxyUrl, [CanBeNull] string clientX509Certificate2ThumbprintOrSubjectName);
     }
 }

--- a/src/WireMock.Net/ResponseBuilders/Response.cs
+++ b/src/WireMock.Net/ResponseBuilders/Response.cs
@@ -37,7 +37,12 @@ namespace WireMock.ResponseBuilders
         /// <summary>
         /// The client X509Certificate2Filename to use.
         /// </summary>
-        public string X509Certificate2Filename { get; private set; } = null;
+        public string X509Certificate2Filename { get; private set; } 
+
+        /// <summary>
+        /// The X509Certificate2 password.
+        /// </summary>
+        public string X509Certificate2Password { get; private set; }
 
         /// <summary>
         /// Gets the response message.
@@ -272,6 +277,21 @@ namespace WireMock.ResponseBuilders
         }
 
         /// <summary>
+        /// With Proxy URL.
+        /// </summary>
+        /// <param name="proxyUrl">The proxy url.</param>
+        /// <param name="clientX509Certificate2Filename">The X509Certificate2 file to use for client authentication.</param>
+        /// /// <param name="clientX509Certificate2Password">The X509Certificate2 password.</param>
+        /// <returns>A <see cref="IResponseBuilder"/>.</returns>
+        public IResponseBuilder WithProxy(string proxyUrl, string clientX509Certificate2Filename, string clientX509Certificate2Password)
+        {
+            Check.NotEmpty(clientX509Certificate2Filename, nameof(clientX509Certificate2Password));
+
+            X509Certificate2Password = clientX509Certificate2Password;
+            return WithProxy(proxyUrl, clientX509Certificate2Filename);
+        }
+
+        /// <summary>
         /// The provide response.
         /// </summary>
         /// <param name="requestMessage">The request.</param>
@@ -285,7 +305,10 @@ namespace WireMock.ResponseBuilders
 
             if (ProxyUrl != null)
             {
-                return await HttpClientHelper.SendAsync(requestMessage, ProxyUrl, X509Certificate2Filename);
+                var requestUri = new Uri(requestMessage.Url);
+                var proxyUri = new Uri(ProxyUrl);
+                var proxyUriWithRequestPathAndQuery = new Uri(proxyUri, requestUri.PathAndQuery);
+                return await HttpClientHelper.SendAsync(requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri, X509Certificate2Filename, X509Certificate2Password);
             }
 
             if (UseTransformer)

--- a/src/WireMock.Net/ResponseBuilders/Response.cs
+++ b/src/WireMock.Net/ResponseBuilders/Response.cs
@@ -35,14 +35,9 @@ namespace WireMock.ResponseBuilders
         public string ProxyUrl { get; private set; }
 
         /// <summary>
-        /// The client X509Certificate2Filename to use.
+        /// The client X509Certificate2 Thumbprint or SubjectName to use.
         /// </summary>
-        public string X509Certificate2Filename { get; private set; } 
-
-        /// <summary>
-        /// The X509Certificate2 password.
-        /// </summary>
-        public string X509Certificate2Password { get; private set; }
+        public string X509Certificate2ThumbprintOrSubjectName { get; private set; } 
 
         /// <summary>
         /// Gets the response message.
@@ -264,31 +259,16 @@ namespace WireMock.ResponseBuilders
         /// With Proxy URL.
         /// </summary>
         /// <param name="proxyUrl">The proxy url.</param>
-        /// <param name="clientX509Certificate2Filename">The X509Certificate2 file to use for client authentication.</param>
+        /// <param name="clientX509Certificate2ThumbprintOrSubjectName">The X509Certificate2 file to use for client authentication.</param>
         /// <returns>A <see cref="IResponseBuilder"/>.</returns>
-        public IResponseBuilder WithProxy(string proxyUrl, string clientX509Certificate2Filename)
+        public IResponseBuilder WithProxy(string proxyUrl, string clientX509Certificate2ThumbprintOrSubjectName)
         {
             Check.NotEmpty(proxyUrl, nameof(proxyUrl));
-            Check.NotEmpty(clientX509Certificate2Filename, nameof(clientX509Certificate2Filename));
+            Check.NotEmpty(clientX509Certificate2ThumbprintOrSubjectName, nameof(clientX509Certificate2ThumbprintOrSubjectName));
 
             ProxyUrl = proxyUrl;
-            X509Certificate2Filename = clientX509Certificate2Filename;
+            X509Certificate2ThumbprintOrSubjectName = clientX509Certificate2ThumbprintOrSubjectName;
             return this;
-        }
-
-        /// <summary>
-        /// With Proxy URL.
-        /// </summary>
-        /// <param name="proxyUrl">The proxy url.</param>
-        /// <param name="clientX509Certificate2Filename">The X509Certificate2 file to use for client authentication.</param>
-        /// /// <param name="clientX509Certificate2Password">The X509Certificate2 password.</param>
-        /// <returns>A <see cref="IResponseBuilder"/>.</returns>
-        public IResponseBuilder WithProxy(string proxyUrl, string clientX509Certificate2Filename, string clientX509Certificate2Password)
-        {
-            Check.NotEmpty(clientX509Certificate2Filename, nameof(clientX509Certificate2Password));
-
-            X509Certificate2Password = clientX509Certificate2Password;
-            return WithProxy(proxyUrl, clientX509Certificate2Filename);
         }
 
         /// <summary>
@@ -308,7 +288,7 @@ namespace WireMock.ResponseBuilders
                 var requestUri = new Uri(requestMessage.Url);
                 var proxyUri = new Uri(ProxyUrl);
                 var proxyUriWithRequestPathAndQuery = new Uri(proxyUri, requestUri.PathAndQuery);
-                return await HttpClientHelper.SendAsync(requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri, X509Certificate2Filename, X509Certificate2Password);
+                return await HttpClientHelper.SendAsync(requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri, X509Certificate2ThumbprintOrSubjectName);
             }
 
             if (UseTransformer)

--- a/src/WireMock.Net/ResponseBuilders/Response.cs
+++ b/src/WireMock.Net/ResponseBuilders/Response.cs
@@ -247,7 +247,7 @@ namespace WireMock.ResponseBuilders
         /// <param name="proxyUrl">The proxy url.</param>
         /// <returns>A <see cref="IResponseBuilder"/>.</returns>
         [PublicAPI]
-        public IResponseBuilder WithProxy(string proxyUrl)
+        public IResponseBuilder WithProxy([NotNull] string proxyUrl)
         {
             Check.NotEmpty(proxyUrl, nameof(proxyUrl));
 
@@ -261,7 +261,7 @@ namespace WireMock.ResponseBuilders
         /// <param name="proxyUrl">The proxy url.</param>
         /// <param name="clientX509Certificate2ThumbprintOrSubjectName">The X509Certificate2 file to use for client authentication.</param>
         /// <returns>A <see cref="IResponseBuilder"/>.</returns>
-        public IResponseBuilder WithProxy(string proxyUrl, string clientX509Certificate2ThumbprintOrSubjectName)
+        public IResponseBuilder WithProxy([NotNull] string proxyUrl, [NotNull] string clientX509Certificate2ThumbprintOrSubjectName)
         {
             Check.NotEmpty(proxyUrl, nameof(proxyUrl));
             Check.NotEmpty(clientX509Certificate2ThumbprintOrSubjectName, nameof(clientX509Certificate2ThumbprintOrSubjectName));

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -133,7 +133,7 @@ namespace WireMock.Server
             var proxyUri = new Uri(settings.Url);
             var proxyUriWithRequestPathAndQuery = new Uri(proxyUri, requestUri.PathAndQuery);
 
-            var responseMessage = await HttpClientHelper.SendAsync(requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri, settings.X509Certificate2Filename, settings.X509Certificate2Password);
+            var responseMessage = await HttpClientHelper.SendAsync(requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri, settings.X509Certificate2ThumbprintOrSubjectName);
 
             if (settings.SaveMapping)
             {
@@ -517,12 +517,12 @@ namespace WireMock.Server
 
             if (!string.IsNullOrEmpty(responseModel.ProxyUrl))
             {
-                if (string.IsNullOrEmpty(responseModel.X509Certificate2Filename))
+                if (string.IsNullOrEmpty(responseModel.X509Certificate2ThumbprintOrSubjectName))
                 {
                     return responseBuilder.WithProxy(responseModel.ProxyUrl);
                 }
 
-                return responseBuilder.WithProxy(responseModel.ProxyUrl, responseModel.X509Certificate2Filename, responseModel.X509Certificate2Password);
+                return responseBuilder.WithProxy(responseModel.ProxyUrl, responseModel.X509Certificate2ThumbprintOrSubjectName);
 
             }
 

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -129,7 +129,11 @@ namespace WireMock.Server
 
         private async Task<ResponseMessage> ProxyAndRecordAsync(RequestMessage requestMessage, ProxyAndRecordSettings settings)
         {
-            var responseMessage = await HttpClientHelper.SendAsync(requestMessage, settings.Url);
+            var requestUri = new Uri(requestMessage.Url);
+            var proxyUri = new Uri(settings.Url);
+            var proxyUriWithRequestPathAndQuery = new Uri(proxyUri, requestUri.PathAndQuery);
+
+            var responseMessage = await HttpClientHelper.SendAsync(requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri, settings.X509Certificate2Filename, settings.X509Certificate2Password);
 
             if (settings.SaveMapping)
             {
@@ -158,7 +162,7 @@ namespace WireMock.Server
             var model = new SettingsModel
             {
                 AllowPartialMapping = _options.AllowPartialMapping,
-                GlobalProcessingDelay = (int?) _options.RequestProcessingDelay?.TotalMilliseconds
+                GlobalProcessingDelay = (int?)_options.RequestProcessingDelay?.TotalMilliseconds
             };
 
             return ToJson(model);
@@ -513,7 +517,13 @@ namespace WireMock.Server
 
             if (!string.IsNullOrEmpty(responseModel.ProxyUrl))
             {
-                return responseBuilder.WithProxy(responseModel.ProxyUrl);
+                if (string.IsNullOrEmpty(responseModel.X509Certificate2Filename))
+                {
+                    return responseBuilder.WithProxy(responseModel.ProxyUrl);
+                }
+
+                return responseBuilder.WithProxy(responseModel.ProxyUrl, responseModel.X509Certificate2Filename, responseModel.X509Certificate2Password);
+
             }
 
             if (responseModel.StatusCode.HasValue)

--- a/src/WireMock.Net/Settings/ProxyAndRecordSettings.cs
+++ b/src/WireMock.Net/Settings/ProxyAndRecordSettings.cs
@@ -16,13 +16,8 @@
         public bool SaveMapping { get; set; } = true;
 
         /// <summary>
-        /// The clientCertificateFilename to use. Example : "C:\certificates\cert.pfx. Must be in .pfx format and include the private key"
+        /// The clientCertificate thumbprint or subject name fragment to use. Example thumbprint : "D2DBF135A8D06ACCD0E1FAD9BFB28678DF7A9818". Example subject name: "www.google.com""
         /// </summary>
-        public string X509Certificate2Filename { get; set; }
-
-        /// <summary>
-        /// The X509Certificate2 password.
-        /// </summary>
-        public string X509Certificate2Password { get; set; }
+        public string X509Certificate2ThumbprintOrSubjectName { get; set; }
     }
 }

--- a/src/WireMock.Net/Settings/ProxyAndRecordSettings.cs
+++ b/src/WireMock.Net/Settings/ProxyAndRecordSettings.cs
@@ -16,8 +16,13 @@
         public bool SaveMapping { get; set; } = true;
 
         /// <summary>
-        /// The clientCertificateFilename to use. Example : "C:\certificates\cert.pfx"
+        /// The clientCertificateFilename to use. Example : "C:\certificates\cert.pfx. Must be in .pfx format and include the private key"
         /// </summary>
         public string X509Certificate2Filename { get; set; }
+
+        /// <summary>
+        /// The X509Certificate2 password.
+        /// </summary>
+        public string X509Certificate2Password { get; set; }
     }
 }

--- a/test/WireMock.Net.Tests/FluentMockServerTests.cs
+++ b/test/WireMock.Net.Tests/FluentMockServerTests.cs
@@ -363,11 +363,28 @@ namespace WireMock.Net.Tests
                 .RespondWith(Response.Create().WithProxy("http://www.google.com"));
 
             // when
-            var result = await new HttpClient().GetStringAsync("http://localhost:" + _server.Ports[0] + "/foo");
+            var result = await new HttpClient().GetStringAsync("http://localhost:" + _server.Ports[0] + "/search?q=test");
 
             // then
             Check.That(result).Contains("google");
         }
+
+        //Leaving commented as this requires an actual certificate with password, along with a service that expects a client certificate
+        [Fact]
+        //public async Task Should_proxy_responses_with_client_certificate()
+        //{
+        //    // given
+        //    _server = FluentMockServer.Start();
+        //    _server
+        //        .Given(Request.Create().WithPath("/*"))
+        //        .RespondWith(Response.Create().WithProxy("https://server-that-expects-a-client-certificate", @"\\yourclientcertificatecontainingprivatekey.pfx", "yourclientcertificatepassword"));
+
+        //    // when
+        //    var result = await new HttpClient().GetStringAsync("http://localhost:" + _server.Ports[0] + "/someurl?someQuery=someValue");
+
+        //    // then
+        //    Check.That(result).Contains("google");
+        //}
 
         //[TearDown]
         public void Dispose()


### PR DESCRIPTION
Add support for client certificate password and test with real services that require client certificates. Also update so when proxying, the path and query will be passed to the proxied api.

Please have a look and let me know what you think. I ran a test for it locally, but it's a bit hard to checkin a runnable unit test as it would require a real service (which I have in my environment) plus a valid pfx with password